### PR TITLE
Feat refactor tests

### DIFF
--- a/.devcontainer/requirements.txt
+++ b/.devcontainer/requirements.txt
@@ -9,3 +9,4 @@ pytest==5.4.1
 pipreqs==0.4.10
 google-cloud-bigquery==1.24.0
 slackclient==2.5.0
+pyarrow==0.17.1

--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ You can use the package as follows:
 from santoku.slack import SlackBotHandler
 
 slack_bot = SlackBotHandler.from_aws_secrets_manager(...)
+slack_bot.send_message(channel="channel", message="Message")
 
-# do something else...
 ```
 
 ## Development
@@ -43,7 +43,12 @@ We provide a development environment that uses Visual Studio Code Remote - Conta
 The containerized environment will automatically forward your local SSH agent if one is running.
 More info [here](https://code.visualstudio.com/docs/remote/containers#_using-ssh-keys) and it works for Windows and Linux.
 
-Talk about .env in home of the project
+## Setting credentials as environment variables
+The code for the tests contains everything the tests need to run with the exception of some credentials, which are (of course) not versioned.
+
+The containerized environment will automatically forward your credentials stored in a .env file and set them as environment variables.
+
+Notice that this means you must have a .env file in the root directory of this project no matter you require credentials or not (the file might be empty).
 
 ### Packaging
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,3 +31,4 @@ six==1.15.0
 slackclient==2.5.0
 urllib3==1.25.9
 yarl==1.4.2
+pyarrow==0.17.1

--- a/santoku/__init__.py
+++ b/santoku/__init__.py
@@ -2,3 +2,4 @@ from santoku import aws
 from santoku import salesforce
 from santoku import google
 from santoku import slack
+from santoku import exceptions

--- a/santoku/exceptions.py
+++ b/santoku/exceptions.py
@@ -1,0 +1,3 @@
+class MissingEnvironmentVariables(Exception):
+    def __init__(self, message):
+        super().__init__(message)

--- a/santoku/salesforce/objects_handler.py
+++ b/santoku/salesforce/objects_handler.py
@@ -58,7 +58,7 @@ class ObjectsHandler:
         password: str,
         client_id: str,
         client_secret: str,
-        api_version: float = 47.0,
+        api_version: str = "47.0",
         grant_type: str = "password",
     ) -> None:
         """
@@ -76,7 +76,7 @@ class ObjectsHandler:
             Consumer key used to authenticate with salesforce.
         client_secret : str
             Consumer secret used to authenticate with salesforce.
-        api_version : float, optional
+        api_version : str, optional
             Version of the Salesforce API used (the default is 47.0).
         grant_type : str, optional
             Type of credentials used to authenticate with salesforce(the default is 'password').
@@ -86,7 +86,7 @@ class ObjectsHandler:
         None
 
         """
-        self._url_to_format = "{}/services/data/v{:.1f}/{}"
+        self._url_to_format = "{}/services/data/v{}/{}"
 
         self._auth_url = auth_url
         self._api_version = api_version
@@ -123,7 +123,7 @@ class ObjectsHandler:
             "client_id_key": "CLIENT_USR",
             "client_secret_key": "CLIENT_PSW",
         },
-        api_version: float = 47.0,
+        api_version: str = "47.0",
         grant_type: str = "password",
     ):
         """

--- a/santoku/salesforce/objects_handler.py
+++ b/santoku/salesforce/objects_handler.py
@@ -175,7 +175,7 @@ class ObjectsHandler:
             "client_secret_key",
         ]:
             if key not in secret_keys:
-                raise ValueError("The `secret_keys` argument does not contain the required key.")
+                raise ValueError("The `secret_keys` argument does not contain the required keys.")
 
         secrets_manager = SecretsManagerHandler()
         credential_info = secrets_manager.get_secret_value(secret_name=secret_name)

--- a/santoku/salesforce/test_objects_handler.py
+++ b/santoku/salesforce/test_objects_handler.py
@@ -9,6 +9,18 @@ from ..salesforce.objects_handler import SalesforceObjectError
 from ..salesforce.objects_handler import SalesforceObjectFieldError
 from ..salesforce.objects_handler import RequestMethodError
 from ..aws import SecretsManagerHandler
+from ..exceptions import MissingEnvironmentVariables
+
+credentials_keys = [
+    "DATA_SCIENCE_SALESFORCE_SANDBOX_AUTH_URL",
+    "DATA_SCIENCE_SALESFORCE_SANDBOX_USR",
+    "DATA_SCIENCE_SALESFORCE_SANDBOX_PSW",
+    "DATA_SCIENCE_SALESFORCE_SANDBOX_CLIENT_USR",
+    "DATA_SCIENCE_SALESFORCE_SANDBOX_CLIENT_PSW",
+]
+
+if not all(key in os.environ for key in credentials_keys):
+    raise MissingEnvironmentVariables("Salesforce credentials environment variables are missing.")
 
 SANDBOX_AUTH_URL = os.environ["DATA_SCIENCE_SALESFORCE_SANDBOX_AUTH_URL"]
 SANDBOX_USR = os.environ["DATA_SCIENCE_SALESFORCE_SANDBOX_USR"]
@@ -56,11 +68,11 @@ def secret_with_default_keys(secrets_manager, request):
 @pytest.fixture(scope="function")
 def secret_keys():
     return {
-        "auth_url_key": "DATA_SCIENCE_SALESFORCE_SANDBOX_AUTH_URL",
-        "username_key": "DATA_SCIENCE_SALESFORCE_SANDBOX_USR",
-        "password_key": "DATA_SCIENCE_SALESFORCE_SANDBOX_PSW",
-        "client_id_key": "DATA_SCIENCE_SALESFORCE_SANDBOX_CLIENT_USR",
-        "client_secret_key": "DATA_SCIENCE_SALESFORCE_SANDBOX_CLIENT_PSW",
+        "auth_url_key": "SF_AUTH_URL",
+        "username_key": "SF_USR",
+        "password_key": "SF_PSW",
+        "client_id_key": "SF_CLIENT_USR",
+        "client_secret_key": "SF_CLIENT_PSW",
     }
 
 

--- a/santoku/slack/slack_bot_handler.py
+++ b/santoku/slack/slack_bot_handler.py
@@ -104,7 +104,7 @@ class SlackBotHandler:
         """
 
         try:
-            response = self.client.chat_postMessage(channel=channel, text=message)
+            self.client.chat_postMessage(channel=channel, text=message)
         except SlackApiError as e:
             # SlackApiError is raised if "ok" is False.
             if e.response["error"] == "invalid_auth":

--- a/santoku/slack/test_slack_bot_handler.py
+++ b/santoku/slack/test_slack_bot_handler.py
@@ -6,6 +6,10 @@ from moto import mock_secretsmanager
 from ..slack import SlackBotHandler
 from ..slack import SlackBotError
 from ..aws import SecretsManagerHandler
+from ..exceptions import MissingEnvironmentVariables
+
+if "SLACK_BOT_API_TOKEN" not in os.environ:
+    raise MissingEnvironmentVariables("Slack bot api token environment variable is missing.")
 
 
 @pytest.fixture(scope="class")


### PR DESCRIPTION
KB-1195: Write dataframe to parquet object in S3.
KB-1195: Salesforce api version changed to string.
KB-1195:  - Readme updated with explanation of required .env file.
- Check of environment variables done at the begining of tests.
- New exceptions module created to handle exceptions shared by the whole project.
KB-1195: Refactor of tests taking profit from pytest fixture files.